### PR TITLE
Fix calculation of ascending node true anomaly

### DIFF
--- a/RasterPropMonitor/Core/OrbitExtensions.cs
+++ b/RasterPropMonitor/Core/OrbitExtensions.cs
@@ -266,7 +266,7 @@ namespace JSI
         public static double TrueAnomalyFromVector(this Orbit o, Vector3d vec)
         {
             Vector3d projected = Vector3d.Exclude(o.SwappedOrbitNormal(), vec);
-            Vector3d vectorToPe = o.eccVec.xzy;
+            Vector3d vectorToPe = o.GetEccVector().xzy;
             double angleFromPe = Math.Abs(Vector3d.Angle(vectorToPe, projected));
 
             //If the vector points to the infalling part of the orbit then we need to do 360 minus the

--- a/RasterPropMonitor/RasterPropMonitor.csproj
+++ b/RasterPropMonitor/RasterPropMonitor.csproj
@@ -98,7 +98,7 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.UI">
-      <HintPath>..\..\..\..\Games\Steam\steamapps\common\Kerbal Space Program\KSP_x64_Data\Managed\UnityEngine.UI.dll</HintPath>
+      <HintPath>..\ksp\Managed\UnityEngine.UI.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.UnityWebRequestWWWModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">


### PR DESCRIPTION
I noticed that the variables `TIMETOANWITHTARGETSECS` and `TIMETODNWITHTARGETSECS` were giving incorrect results, and eventually tracked it down to this change.

[The docs for GetEccVector](https://kerbalspaceprogram.com/api/class_orbit.html#a114d2c198ce639b5e778a8c977b9e009) say "use instead of Orbit.eccVec for non-updating orbits when in a rotating ref frame". I don't really understand what that means, but does fix the issue for me in-game.

Also included a minor fix to the project file.