### PR TITLE
Fixes a memory leak in RPMVesselComputer.cs

### DIFF
--- a/LGG Changes.txt
+++ b/LGG Changes.txt
@@ -1,0 +1,8 @@
+Linuxgurugamer Changes
+
+Bug:
+	Four GameEvent callbacks weren't being released upon leaving the flight scene.  These were memory leaks and could cause other problems
+
+Fix
+	In the RPMVesselComputer.cs, in the OnDestroy method, remove the check for scene == FLIGHT.  Not needed since this can only be called when in flight, and by the time the OnDestroy is called, it isn't in flight anymore
+	in the RPMVesselComputer.cs, in the OnDestroy method, moved check for vessel == nul to AFTER the removal of the callbacks from the GameEvents

--- a/RasterPropMonitor/Core/RPMVesselComputer.cs
+++ b/RasterPropMonitor/Core/RPMVesselComputer.cs
@@ -684,14 +684,10 @@ namespace JSI
 
         public void OnDestroy()
         {
-            if (vessel == null)// || vid == Guid.Empty)
-            {
-                return;
-            }
-            if (!HighLogic.LoadedSceneIsFlight)
-            {
-                return;
-            }
+            //if (!HighLogic.LoadedSceneIsFlight)
+            //{
+            //    return;
+            //}
 
             //if (vid != vessel.id)
             //{
@@ -707,6 +703,11 @@ namespace JSI
             GameEvents.onPartUndock.Remove(onPartUndock);
 #endif
             GameEvents.onVesselDestroy.Remove(onVesselDestroy);
+
+            if (vessel == null)// || vid == Guid.Empty)
+            {
+                return;
+            }
 
             // This very likely was handled in the OnVesselDestroy callback,
             // but there is no harm trying again here.


### PR DESCRIPTION
This bug was detected using KSP Community Fixes

Bug:
	Four GameEvent callbacks weren't being released upon leaving the flight scene.  These were memory leaks and could cause other problems

Fix
	In the RPMVesselComputer.cs, in the OnDestroy method, remove the check for scene == FLIGHT.  Not needed since this can only be called when in flight, and by the time the OnDestroy is called, it isn't in flight anymore
	in the RPMVesselComputer.cs, in the OnDestroy method, moved check for vessel == nul to AFTER the removal of the callbacks from the GameEvents
