### PR TITLE
Add trailing slash to external-camera.restockwhitelist file to fix ExternalCamera

### DIFF
--- a/GameData/JSI/RasterPropMonitor/Library/Parts/ExternalCameraPart/external-camera.restockwhitelist
+++ b/GameData/JSI/RasterPropMonitor/Library/Parts/ExternalCameraPart/external-camera.restockwhitelist
@@ -1,2 +1,2 @@
 Squad/Parts/Utility/linearVernorRCS/Assets/
-Squad/Parts/Engine/liquidEngineLV-1_v2/Assets
+Squad/Parts/Engine/liquidEngineLV-1_v2/Assets/


### PR DESCRIPTION
According to [ReStock's wiki](https://github.com/PorktoberRevolution/ReStocked/wiki/Asset-Blacklist-and-Whitelist), the whitelist / blacklist syntax requires a trailing slash to recognize a line as a directory vs a wildcard match for any type of file. Without this slash and with ReStock installed, the external camera part does not load. Adding the slash fixes this issue.