### PR TITLE
Add a ExtCam dedicated pageHandler to dynamically display camera's ID/Name

### DIFF
--- a/RasterPropMonitor/Handlers/JSICameraStatusPage.cs
+++ b/RasterPropMonitor/Handlers/JSICameraStatusPage.cs
@@ -1,0 +1,171 @@
+/*****************************************************************************
+ * RasterPropMonitor
+ * =================
+ * Plugin for Kerbal Space Program
+ *
+ *  by Mihara (Eugene Medvedev), MOARdV, and other contributors
+ *
+ * RasterPropMonitor is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, revision
+ * date 29 June 2007, or (at your option) any later version.
+ *
+ * RasterPropMonitor is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with RasterPropMonitor.  If not, see <http://www.gnu.org/licenses/>.
+ ****************************************************************************/
+using System.Text;
+using UnityEngine;
+
+namespace JSI
+{
+    /// <summary>
+    /// Page handler that reports camera status from the current page's background
+    /// JSISteerableCamera instance. This avoids global PLUGIN_*/PERSISTENT_*
+    /// resolution ambiguity when multiple MFDs exist in the same cockpit.
+    /// </summary>
+    public class JSICameraStatusPage : InternalModule
+    {
+        private const string CameraStatusToken = "__CAMERA_STATUS__";
+        private static readonly string DefaultOverlayTemplate = @"[font0][@y+2][hw]         __CAMERA_STATUS__";
+
+        [KSPField]
+        public string prefix = "";
+        [KSPField]
+        public string idLabel = "ID";
+        [KSPField]
+        public string nameLabel = "CAMERA";
+        [KSPField]
+        public string unknownText = "N/A";
+        [KSPField]
+        public bool showId = true;
+        [KSPField]
+        public bool showName = true;
+        [KSPField]
+        public string statusColor = "[#FFFF0066]";
+        [KSPField]
+        public string statusSuffix = "[#FFFFFF55]";
+        [KSPField]
+        public string overlayTemplate = string.Empty;
+        [KSPField]
+        public string overlayTemplatePath = string.Empty;
+        [KSPField]
+        public string cameraStatusToken = CameraStatusToken;
+
+        private JSISteerableCamera steerableCamera;
+        private string resolvedTemplate;
+
+        public void GetHandlerReferences(MonoBehaviour pageHandler, MonoBehaviour backgroundHandler)
+        {
+            steerableCamera = backgroundHandler as JSISteerableCamera;
+        }
+
+        // Analysis disable UnusedParameter
+        public string ShowStatus(int width, int height)
+        {
+            if (steerableCamera == null)
+            {
+                // Fallback: if handler references were not wired for some reason,
+                // try to resolve a camera from the current prop only.
+                foreach (InternalModule module in internalProp.internalModules)
+                {
+                    steerableCamera = module as JSISteerableCamera;
+                    if (steerableCamera != null)
+                    {
+                        break;
+                    }
+                }
+            }
+
+            string statusLine = BuildStatusLine();
+            string template = GetTemplate();
+            return InjectStatusLine(template, statusLine);
+        }
+        // Analysis restore UnusedParameter
+
+        private string GetTemplate()
+        {
+            if (!string.IsNullOrEmpty(resolvedTemplate))
+            {
+                return resolvedTemplate;
+            }
+
+            if (!string.IsNullOrEmpty(overlayTemplate))
+            {
+                resolvedTemplate = overlayTemplate;
+                return resolvedTemplate;
+            }
+
+            if (!string.IsNullOrEmpty(overlayTemplatePath))
+            {
+                resolvedTemplate = JUtil.LoadPageDefinition(overlayTemplatePath);
+                if (!string.IsNullOrEmpty(resolvedTemplate))
+                {
+                    return resolvedTemplate;
+                }
+            }
+
+            resolvedTemplate = DefaultOverlayTemplate;
+            return resolvedTemplate;
+        }
+
+        private string InjectStatusLine(string template, string statusLine)
+        {
+            string token = string.IsNullOrEmpty(cameraStatusToken) ? CameraStatusToken : cameraStatusToken;
+
+            if (template.Contains(token))
+            {
+                return template.Replace(token, statusLine);
+            }
+
+            // Final fallback if no marker is present.
+            return statusLine + "\n" + template;
+        }
+
+        private string BuildStatusLine()
+        {
+            if (steerableCamera == null)
+            {
+                return string.Format("{0}{1} {2}{3}", statusColor, prefix, unknownText, statusSuffix);
+            }
+
+            double activeId = steerableCamera.GetActiveCameraID();
+            string activeName = steerableCamera.GetActiveCameraTransform();
+            bool validId = activeId >= 1.0;
+            if (string.IsNullOrEmpty(activeName))
+            {
+                activeName = unknownText;
+            }
+
+            StringBuilder sb = new StringBuilder();
+            sb.Append(statusColor);
+            sb.Append(prefix);
+
+            if (showId)
+            {
+                sb.Append(' ');
+                sb.Append(idLabel);
+                sb.Append(':');
+                sb.Append(validId ? ((int)activeId).ToString() : unknownText);
+            }
+
+            if (showName)
+            {
+                if (showId)
+                {
+                    sb.Append(' ');
+                }
+                sb.Append(nameLabel);
+                sb.Append(':');
+                sb.Append(validId ? activeName : unknownText);
+            }
+
+            sb.Append(statusSuffix);
+            return sb.ToString();
+        }
+    }
+}

--- a/RasterPropMonitor/Handlers/JSISteerableCamera.cs
+++ b/RasterPropMonitor/Handlers/JSISteerableCamera.cs
@@ -508,10 +508,7 @@ namespace JSI
 
             if (!skipMissingCameras)
             {
-                //if (rpmComp != null)
-                //{
-                //    rpmComp.SetPropVar(cameraInfoVarName + "_ID", internalProp.propID, currentCamera + 1);
-                //}
+
                 return;
             }
 
@@ -704,6 +701,30 @@ namespace JSI
                     }
                 }
             }
+        }
+
+        /// <summary>
+        /// Returns the active camera id (1-based).  Intended for plugin variable access
+        /// via VARIABLE = PLUGIN_JSISteerableCamera:GetActiveCameraID
+        /// </summary>
+        /// <returns>camera id (1-based) or -1 if none</returns>
+        public double GetActiveCameraID()
+        {
+            if (cameras == null || cameras.Count == 0) return -1.0;
+            return cameras[currentCamera].cameraId;
+        }
+
+        /// <summary>
+        /// Returns the active camera transform/name as a string.
+        /// Intended for plugin variable access via
+        /// VARIABLE = PLUGIN_JSISteerableCamera:GetActiveCameraTransform
+        /// Note: depending on evaluator support, numeric ID may be more reliable.
+        /// </summary>
+        /// <returns>camera transform/name or empty string</returns>
+        public string GetActiveCameraTransform()
+        {
+            if (cameras == null || cameras.Count == 0) return string.Empty;
+            return cameras[currentCamera].cameraTransform ?? string.Empty;
         }
     }
 

--- a/RasterPropMonitor/Handlers/JSISteerableCamera.cs
+++ b/RasterPropMonitor/Handlers/JSISteerableCamera.cs
@@ -522,10 +522,6 @@ namespace JSI
                 gotCamera = cameraObject.PointCamera(cameras[currentCamera]);
             }
 
-            //if (rpmComp != null)
-            //{
-            //    rpmComp.SetPropVar(cameraInfoVarName + "_ID", internalProp.propID, currentCamera + 1);
-            //}
         }
 
         private void SelectNextCamera()
@@ -628,19 +624,6 @@ namespace JSI
 
             homeCrosshairMaterial = new Material(Shader.Find("KSP/Alpha/Unlit Transparent"));
             homeCrosshairMaterial.color = ConfigNode.ParseColor32(homeCrosshairColor);
-
-            if (!string.IsNullOrEmpty(cameraInfoVarName))
-            {
-                //rpmComp = RasterPropMonitorComputer.Instantiate(internalProp);
-                //if (rpmComp.HasPropVar(cameraInfoVarName + "_ID", internalProp.propID))
-                //{
-                //    currentCamera = rpmComp.GetPropVar(cameraInfoVarName + "_ID", internalProp.propID) - 1;
-                //}
-                //else
-                //{
-                //    rpmComp.SetPropVar(cameraInfoVarName + "_ID", internalProp.propID, currentCamera + 1);
-                //}
-            }
 
             if (!string.IsNullOrEmpty(cameraEffectShader))
             {


### PR DESCRIPTION
I've seen some commented code that were trying to set the camera ID in a persistent variable.
I assume this was motivated by the idea to display the camera ID in MFDs

I've tried to play a bit around this topic and I figure out there were no easy way to access camera's `ID` or `Transform` from the text overlay. This brings up issue of finding the right persistent variable (or plugin getter) when several MFDs exists in the scene (almost every time, actually).

Therefore, after digging a bit. I changed the strategy : 
I created another module meant to be used as a pageHandler. In Addition with the existing `JSISteerableCamera` module used as `backgroudHandler`

- It is still possible to use the previously used textOverlay.
- It is possible to forward the previously used textOverlay to the pageHandler (`JSICameraStatusPage') to keep the flexibility provided by text overlays -> This will search and replace the `CameraStatusToken` (.i.e. `"__CAMERA_STATUS__"`) in the overlay with the actual camera name or ID, depending on the configuration of the module.
- If the internal module `JSICameraStatusPage` is used in a page, it override the `text =`attribute of this page.

I'm aware that this PR might not be as clean as I wish since I'm not really experienced in KSP modding. But I'm feeling this might be a good starting point for discussions. And see if such a feature would interest anyone.

## Exemple 
------
Here is a config extract for an MFD (ALCORMFD40x20) : 
```cfg
// --------------------Page 07	'External Cameras'----------------------------------------

		PAGE
		{
			name = pExtCam-1-40x20
			button = buttonR7
			textureInterlayURL = ASET/ASET_Props/MFDs/ALCORMFD40x20/bg01
			// text = ASET/ASET_Props/MFDs/ALCORMFD40x20/ALCORExtraCamsOverlay.txt			
			PAGEHANDLER
			{
				name = JSICameraStatusPage
				method = ShowStatus
				getHandlerReferencesMethod = GetHandlerReferences
				overlayTemplatePath = ASET/ASET_Props/MFDs/ALCORMFD40x20/ALCORExtraCamsOverlay.txt	
				prefix = 
				idLabel = ID
				nameLabel = Camera
				unknownText = N/A
				showId = false
				showName = true
			}
			BACKGROUNDHANDLER
			{
				name = JSISteerableCamera
				method = RenderCamera
				pageActiveMethod = PageActive
				cameraInfoVarName = EXTcam
				skipMissingCameras = true
				showNoSignal = yes
				buttonClickMethod = ClickProcessor
				buttonReleaseMethod = ReleaseProcessor
				cameraTransform = ExtCam1|ExtCam2|ExtCam3|ExtCam4|ExtCam5|ExtCam6|ExtCam7|ExtCam8|ALCORExt_A_CamTransform|ALCORExt_B_CamTransform|ALCORExt_C_CamTransform|ALCORExt_D_CamTransform|ALCORExt_E_CamTransform
				fovLimits = 90,5|90,5|90,5|90,5|90,5|90,5|90,5|90,5|90,15|90,15|110,5|110,5|90,5
				{...}
			}
		} 
```

Notice that I commented the original text field (but I could left it as is, since it is override by the pageHandler.
Also, note that I copied its path to forward it to JSICameraStatusPage through `overlayTemplatePath` so my display stays the same.

I only added `__CAMERA_STATUS__` in the overlay orignal fine at the place I wanted to display the camera's name.
